### PR TITLE
Enable building & running HaWoR's masked DROID-SLAM on AMD ROCm (gfx942 / MI300X)

### DIFF
--- a/rocm_patches/README.md
+++ b/rocm_patches/README.md
@@ -1,0 +1,53 @@
+# Running HaWoR's masked DROID-SLAM on AMD ROCm (gfx942 / MI300X)
+
+The masked DROID-SLAM CUDA extension (`thirdparty/DROID-SLAM`) and its `lietorch`
+sub-dependency build and run on AMD ROCm via PyTorch's HIP/`hipify` path. This
+branch (`amd_support`) carries the minimal, upstreamable fixes.
+
+## Validated environment
+
+- Node: AMD Instinct MI300X (`gfx942`)
+- Container: `rocm/pytorch:rocm7.2_ubuntu22.04_py3.10_pytorch_release_2.10.0`
+  (torch 2.10.0+rocm7.2, HIP 7.2)
+- `torch_scatter`: prebuilt ROCm wheel from
+  [pyg-rocm-build](https://github.com/Looong01/pyg-rocm-build) release 15
+  (`torch-2.10.0-rocm-*-py310`); avoids building `torch-scatter` from source.
+- `PYTORCH_ROCM_ARCH=gfx942`; all visualization run headless.
+
+## The five ROCm fixes
+
+Committed **in-tree** on this branch:
+
+- **P1** `thirdparty/DROID-SLAM/setup.py` — gate the NVIDIA `-gencode=arch=compute_*`
+  flags behind `torch.version.hip is None`. On ROCm the target arch comes from
+  `PYTORCH_ROCM_ARCH`; clang++/hipcc rejects `-gencode`. CUDA builds are unchanged.
+- **P4** `thirdparty/DROID-SLAM/src/{correlation_kernels,altcorr_kernel}.cu` —
+  `AT_DISPATCH_*` was passed the deprecated `Tensor.type()`. Newer torch's
+  `DeprecatedTypeProperties` no longer converts to `ScalarType`; use
+  `.scalar_type()` (correct on both CUDA and ROCm).
+
+Applied to the **submodules** by `rocm_patches/apply_rocm_submodule_patches.sh`
+(submodule internals cannot be committed from this repo):
+
+- **P2** `lietorch/setup.py` — same `-gencode` strip.
+- **P3** `lietorch/lietorch/src/lietorch_gpu.cu` — add the `template`
+  disambiguator: `Matrix4x4().block<3,3>` → `Matrix4x4().template block<3,3>`
+  (required by clang/hipcc for dependent member templates).
+- **P5** `eigen/.../SparseCore/SparseMatrix.h` — `EIGEN_USING_STD(fill_n)` expands
+  to `using ::fill_n;` under `__HIPCC__/__CUDACC__`; force `using std::fill_n;`.
+
+## Build steps
+
+```bash
+git submodule update --init --recursive
+bash rocm_patches/apply_rocm_submodule_patches.sh   # P2/P3/P5 (submodules)
+cd thirdparty/DROID-SLAM
+PYTORCH_ROCM_ARCH=gfx942 python setup.py install     # builds droid_backends + lietorch
+```
+
+## Functional GPU smoke
+
+`droid_backends` was validated on `gfx942` by exercising the ported kernels on the
+GPU: `iproj` / `projmap` / `frame_distance` (from `droid_kernels.cu`, the P5 Eigen
+path) and `corr_index_forward` / `altcorr_forward` (the P4 `.scalar_type()` path),
+alongside `lietorch.SE3` and `torch_scatter.scatter_mean`.

--- a/rocm_patches/apply_rocm_submodule_patches.sh
+++ b/rocm_patches/apply_rocm_submodule_patches.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Apply the ROCm/HIP source fixes that live inside the git submodules of the
+# masked DROID-SLAM (lietorch, eigen). Submodule internals cannot be committed
+# from this repo, so run this once after `git submodule update --init --recursive`
+# and before building `thirdparty/DROID-SLAM`.
+#
+# The in-tree fixes (masked DROID-SLAM setup.py gencode gate + .type()->.scalar_type()
+# in src/*.cu) are already committed on this branch and need no action here.
+#
+# Idempotent: safe to re-run.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DROID="${HERE}/../thirdparty/DROID-SLAM"
+LIET="${DROID}/thirdparty/lietorch"
+EIGEN="${DROID}/thirdparty/eigen"
+
+echo "[rocm-patch] lietorch/eigen submodule fixes"
+
+# P2: lietorch's own setup.py hardcodes NVIDIA -gencode flags -> hipcc/clang++
+# rejects them. Strip on any build (arch comes from PYTORCH_ROCM_ARCH on ROCm).
+if [ -f "${LIET}/setup.py" ]; then
+  sed -i '/gencode=arch=compute/d' "${LIET}/setup.py"
+  echo "  P2 patched ${LIET}/setup.py (removed -gencode)"
+fi
+
+# P3: dependent member-template call needs the `template` disambiguator under
+# clang/hipcc: Matrix4x4().block<3,3>(...) -> Matrix4x4().template block<3,3>(...)
+if [ -f "${LIET}/lietorch/src/lietorch_gpu.cu" ]; then
+  sed -i 's/Matrix4x4()\.block<3,3>/Matrix4x4().template block<3,3>/' \
+    "${LIET}/lietorch/src/lietorch_gpu.cu"
+  echo "  P3 patched lietorch_gpu.cu (.template)"
+fi
+
+# P5: bundled Eigen uses EIGEN_USING_STD(fill_n); under hipcc (__HIPCC__/__CUDACC__
+# defined) that macro expands to `using ::fill_n;` (global namespace, which has no
+# fill_n) -> force the std:: qualified name.
+if [ -d "${EIGEN}/Eigen" ]; then
+  grep -rl 'EIGEN_USING_STD(fill_n)' "${EIGEN}/Eigen" 2>/dev/null | \
+    xargs -r sed -i 's/EIGEN_USING_STD(fill_n);/using std::fill_n;/g'
+  echo "  P5 patched eigen EIGEN_USING_STD(fill_n) -> using std::fill_n"
+fi
+
+echo "[rocm-patch] done"

--- a/thirdparty/DROID-SLAM/setup.py
+++ b/thirdparty/DROID-SLAM/setup.py
@@ -1,8 +1,23 @@
 from setuptools import setup
 from torch.utils.cpp_extension import BuildExtension, CUDAExtension
+import torch
 
 import os.path as osp
 ROOT = osp.dirname(osp.abspath(__file__))
+
+# On AMD ROCm/HIP the sources are hipified and compiled by clang++ (hipcc), which
+# rejects NVIDIA-only `-gencode=arch=compute_*` flags. The target GPU arch is taken
+# from the PYTORCH_ROCM_ARCH env var (e.g. gfx942) instead. Keep the CUDA gencode
+# list only when building against a CUDA toolkit.
+IS_ROCM = torch.version.hip is not None
+CUDA_ARCH_FLAGS = [] if IS_ROCM else [
+    '-gencode=arch=compute_60,code=sm_60',
+    '-gencode=arch=compute_61,code=sm_61',
+    '-gencode=arch=compute_70,code=sm_70',
+    '-gencode=arch=compute_75,code=sm_75',
+    '-gencode=arch=compute_80,code=sm_80',
+    '-gencode=arch=compute_86,code=sm_86',
+]
 
 setup(
     name='droid_backends',
@@ -17,14 +32,7 @@ setup(
             ],
             extra_compile_args={
                 'cxx': ['-O3'],
-                'nvcc': ['-O3',
-                    '-gencode=arch=compute_60,code=sm_60',
-                    '-gencode=arch=compute_61,code=sm_61',
-                    '-gencode=arch=compute_70,code=sm_70',
-                    '-gencode=arch=compute_75,code=sm_75',
-                    '-gencode=arch=compute_80,code=sm_80',
-                    '-gencode=arch=compute_86,code=sm_86',
-                ]
+                'nvcc': ['-O3'] + CUDA_ARCH_FLAGS,
             }),
     ],
     cmdclass={ 'build_ext' : BuildExtension }
@@ -47,14 +55,7 @@ setup(
                 'thirdparty/lietorch/lietorch/src/lietorch_cpu.cpp'],
             extra_compile_args={
                 'cxx': ['-O2'], 
-                'nvcc': ['-O2',
-                    '-gencode=arch=compute_60,code=sm_60', 
-                    '-gencode=arch=compute_61,code=sm_61', 
-                    '-gencode=arch=compute_70,code=sm_70', 
-                    '-gencode=arch=compute_75,code=sm_75',
-                    '-gencode=arch=compute_80,code=sm_80',
-                    '-gencode=arch=compute_86,code=sm_86',                 
-                ]
+                'nvcc': ['-O2'] + CUDA_ARCH_FLAGS,
             }),
     ],
     cmdclass={ 'build_ext' : BuildExtension }

--- a/thirdparty/DROID-SLAM/src/altcorr_kernel.cu
+++ b/thirdparty/DROID-SLAM/src/altcorr_kernel.cu
@@ -306,7 +306,7 @@ std::vector<torch::Tensor> altcorr_cuda_forward(
   const dim3 threads(BLOCK_H, BLOCK_W);
 
 
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(fmap1.type(), "altcorr_forward_kernel", ([&] {
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(fmap1.scalar_type(), "altcorr_forward_kernel", ([&] {
     altcorr_forward_kernel<scalar_t><<<blocks, threads>>>(
         fmap1.packed_accessor32<scalar_t,4,torch::RestrictPtrTraits>(),
         fmap2.packed_accessor32<scalar_t,4,torch::RestrictPtrTraits>(),

--- a/thirdparty/DROID-SLAM/src/correlation_kernels.cu
+++ b/thirdparty/DROID-SLAM/src/correlation_kernels.cu
@@ -142,7 +142,7 @@ std::vector<torch::Tensor> corr_index_cuda_forward(
   torch::Tensor corr = torch::zeros(
     {batch_size, 2*radius+1, 2*radius+1, ht, wd}, opts);
 
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(volume.type(), "sampler_forward_kernel", ([&] {
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(volume.scalar_type(), "sampler_forward_kernel", ([&] {
     corr_index_forward_kernel<scalar_t><<<blocks, threads>>>(
       volume.packed_accessor32<scalar_t,5,torch::RestrictPtrTraits>(),
       coords.packed_accessor32<float,4,torch::RestrictPtrTraits>(),
@@ -173,7 +173,7 @@ std::vector<torch::Tensor> corr_index_cuda_backward(
   const dim3 threads(BLOCK, BLOCK);
 
 
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(volume.type(), "sampler_backward_kernel", ([&] {
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(volume.scalar_type(), "sampler_backward_kernel", ([&] {
     corr_index_backward_kernel<scalar_t><<<blocks, threads>>>(
       coords.packed_accessor32<float,4,torch::RestrictPtrTraits>(),
       corr_grad.packed_accessor32<scalar_t,5,torch::RestrictPtrTraits>(),


### PR DESCRIPTION
## Summary

Enables HaWoR's vendored **masked DROID-SLAM** CUDA extension (`thirdparty/DROID-SLAM`)
and its `lietorch` sub-dependency to build and run on AMD GPUs (ROCm/HIP) through
PyTorch's `hipify` path. The CUDA/nvcc build path is unchanged — the fixes are gated
behind `torch.version.hip` or are equally correct on both toolchains.

The in-repo change is intentionally minimal (one `setup.py` + two `.cu` files). The
three fixes that live *inside* the submodules (`lietorch`, bundled `Eigen`) can't be
committed from this repo, so they ship as a small idempotent script plus a build guide
under `rocm_patches/`.

Validated on an AMD Instinct MI300X, both at the kernel level (GPU smoke) **and** by
running the full `demo.py` pipeline end-to-end on a real 121-frame egocentric clip.

## Changes

Committed **in-tree**:

- **`thirdparty/DROID-SLAM/setup.py`** — gate the NVIDIA `-gencode=arch=compute_*`
  flags behind `torch.version.hip is None`. On ROCm the target arch comes from
  `PYTORCH_ROCM_ARCH` (e.g. `gfx942`); clang++/hipcc rejects `-gencode`. CUDA builds
  keep the exact same gencode list.
- **`thirdparty/DROID-SLAM/src/altcorr_kernel.cu`** and **`src/correlation_kernels.cu`**
  — pass `Tensor.scalar_type()` to `AT_DISPATCH_FLOATING_TYPES_AND_HALF` instead of the
  deprecated `Tensor.type()`. Newer PyTorch's `DeprecatedTypeProperties` no longer
  implicitly converts to `ScalarType`; `.scalar_type()` is correct on CUDA and ROCm.

Shipped as a helper for the **submodules** (`rocm_patches/apply_rocm_submodule_patches.sh`):

- **`lietorch/setup.py`** — same `-gencode` strip.
- **`lietorch/lietorch/src/lietorch_gpu.cu`** — add the `template` disambiguator:
  `Matrix4x4().block<3,3>` → `Matrix4x4().template block<3,3>` (clang/hipcc require it
  for a dependent member template; nvcc is lenient).
- **bundled `Eigen` `SparseMatrix.h`** — `EIGEN_USING_STD(fill_n)` expands to
  `using ::fill_n;` under `__HIPCC__/__CUDACC__` (no `::fill_n`); force `using std::fill_n;`.

No generated HIP sources are checked in — `hipify` runs at build time.

## Reproduction

### 1. Build (this PR)

```bash
# ROCm PyTorch container:
#   rocm/pytorch:rocm7.2_ubuntu22.04_py3.10_pytorch_release_2.10.0   (torch 2.10+rocm7.2)
git clone --recursive -b amd_support https://github.com/ZJLi2013/HaWoR.git
cd HaWoR
git submodule update --init --recursive
export PYTORCH_ROCM_ARCH=gfx942

# torch_scatter: prebuilt ROCm wheel (avoids source build); import name stays torch_scatter
pip install <pyg-rocm-build torch-2.10.0-rocm-*-py310 torch_scatter wheel>

# submodule-internal ROCm fixes (P2/P3/P5)
bash rocm_patches/apply_rocm_submodule_patches.sh

# build droid_backends + lietorch
cd thirdparty/DROID-SLAM && PYTORCH_ROCM_ARCH=gfx942 python setup.py install && cd -

python - <<'PY'
import torch, lietorch, droid_backends
print(torch.__version__, torch.version.hip, "| lietorch + droid_backends import ok")
PY
```

### 2. Full `demo.py` pipeline (end-to-end validation)

The rest of HaWoR (WiLoR detector, HaWoR motion net, Metric3D, MANO infiller) is plain
PyTorch/ViT and runs on ROCm as-is. A few environment notes to run the demo unattended:

```bash
# python deps (numpy<2 stack): opencv, smplx, mmcv==1.7.2 (--no-build-isolation),
# pytorch-lightning==2.2.4, aitviewer, chumpy (patch its numpy import), setuptools<81, ffmpeg
# weights (all via public mirrors): ThunderVVV/HaWoR (detector.pt, droid.pth, hawor.ckpt,
#   infiller.pt, metric_depth_vit_large_800k.pth) + MANO_{LEFT,RIGHT}.pkl

export TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD=1   # torch 2.6+ weights_only=True rejects Lightning ckpt
export QT_QPA_PLATFORM=offscreen MPLBACKEND=Agg   # cv2/matplotlib pull Qt; force headless

python demo.py --video_path ./example/video_0.mp4 --vis_mode world
```

Stage outputs land under `example/video_0/`: `tracks_0_121/` (detection boxes, masks,
tracks), `cam_space/{0,1}/*.json` (per-hand MANO), `SLAM/hawor_slam_w_scale_0_121.npz`
(world-space camera trajectory — **the masked-DROID-SLAM output**), and
`world_space_res.pth` (the final **world-space hand motion** for both hands over all
frames, saved before the render step).

### 3. Visualize the world-space 3D hand motion (no GL)

HaWoR's core output is the continuous, global 3D hand trajectory. The demo's built-in
aitviewer renderer needs OpenGL, which hangs under headless software GL on the node.
`world_space_res.pth` already holds the result, so it can be visualized without GL:
run MANO forward on the ROCm GPU and plot with matplotlib (Agg backend).

```bash
MPLBACKEND=Agg python make_world_traj_video.py   # -> hawor_rocm_world_hand_motion.mp4
```
This loads `world_space_res.pth`, calls `run_mano_twohands(...)` (MANO forward on ROCm →
world-space verts `(2,T,778,3)` + joints `(2,T,21,3)`), and renders a rotating 3D
hand-mesh turntable with the wrist trajectory trail.

## Tested On

- GPU: **AMD Instinct MI300X** (gfx942)
- ROCm: 7.2 (HIP 7.2)
- PyTorch: 2.10.0 (ROCm Docker build)
- Docker: `rocm/pytorch:rocm7.2_ubuntu22.04_py3.10_pytorch_release_2.10.0`

## Results

**Kernel-level GPU smoke** — `droid_backends` ported kernels run correctly on gfx942:
`iproj` / `projmap` / `frame_distance` (from `droid_kernels.cu`, the P5 Eigen path),
`corr_index_forward` / `altcorr_forward` (the P4 `.scalar_type()` path), plus
`lietorch.SE3` and `torch_scatter.scatter_mean`.

**Full pipeline end-to-end** — `demo.py` on a real 121-frame egocentric clip
(`example/video_0.mp4`) completes every GPU stage on MI300X:

| Stage | Status |
|---|---|
| WiLoR hand detection + tracking | ✅ GPU |
| HaWoR motion estimation (ViT + IAM + MANO) | ✅ GPU |
| **masked DROID-SLAM** (this PR's target) → `hawor_slam_w_scale_0_121.npz` | ✅ GPU |
| Metric3D metric depth | ✅ GPU |
| MANO infiller (left + right hand) | ✅ GPU |

Two viewable videos were produced (both bypass the GL renderer):

1. **`hawor_rocm_world_hand_motion.mp4`** — HaWoR's core output: the world-space,
   continuous 3D hand motion. MANO is run forward on the ROCm GPU from
   `world_space_res.pth`; a rotating 3D hand-mesh turntable + wrist trajectory is drawn
   with matplotlib.
2. **`hawor_rocm_overlay.mp4`** — the 2D perception front-end: ROCm-computed hand
   segmentation masks (also the masked-DROID-SLAM input masks) + WiLoR detection boxes
   overlaid on the 121 frames.

## Known limitations (not ROCm-compute issues)

- The demo's built-in **aitviewer photorealistic render** (hand mesh composited back
  onto the video) hangs under headless software GL (`Xvfb`+`llvmpipe`): moderngl's
  offscreen context reports `QOpenGLContext::swapBuffers() called with non-exposed
  window` then CPU-spins without emitting frames. This is a headless-GL/EGL setup
  problem, orthogonal to the kernel port — every GPU compute stage still produces its
  output, and the world-space 3D hand motion is visualized separately (above) without GL.
- `pytorch3d` (used only for the hand-mask *render*) is another CUDA extension; on ROCm
  the demo stubs it out, so SLAM runs **unmasked** (trajectory still produced). Building
  pytorch3d-on-ROCm is out of scope for this PR.

## Notes

- Backward-compatible with CUDA/nvcc (gencode gate + `.scalar_type()` are correct there too).
- `lietorch` needs one more fix upstream (`.template`, tracked in `princeton-vl/lietorch`);
  here it's covered by the `rocm_patches` script since HaWoR pins an older lietorch snapshot.



https://github.com/user-attachments/assets/9d1c1ee3-fac6-4675-9673-ac51e208692f


https://github.com/user-attachments/assets/33f513ae-6fb9-4067-a1bb-36904f3cd441



